### PR TITLE
[FPGA] Added sim target to zero-copy-data-transfer

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
@@ -94,6 +94,10 @@ To learn more about the extensions and how to configure the oneAPI environment, 
      ```
      make fpga_emu
      ```
+   * Compile for simulation (medium compile time, targets simulated FPGA device):
+     ```
+     make fpga_sim
+     ```
    * Generate the optimization report:
      ```
      make report
@@ -126,6 +130,10 @@ To learn more about the extensions and how to configure the oneAPI environment, 
    * Compile for emulation (fast compile time, targets emulated FPGA device):
      ```
      nmake fpga_emu
+     ```
+   * Compile for simulation (medium compile time, targets simulated FPGA device):
+     ```
+     nmake fpga_sim
      ```
    * Generate the optimization report:
      ```
@@ -164,7 +172,12 @@ Locate `report.html` in the `zero_copy_data_transfer_report.prj/reports/` direct
      ./zero_copy_data_transfer.fpga_emu     (Linux)
      zero_copy_data_transfer.fpga_emu.exe   (Windows)
      ```
-2. Run the sample on the FPGA device:
+ 2. Run the sample on the FPGA simulator:
+     ```
+     ./zero_copy_data_transfer.fpga_sim     (Linux)
+     zero_copy_data_transfer.fpga_sim.exe   (Windows)
+     ```
+ 3. Run the sample on the FPGA device:
      ```
      ./zero_copy_data_transfer.fpga         (Linux)
      zero_copy_data_transfer.fpga.exe       (Windows)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCE_FILE zero_copy_data_transfer.cpp)
 set(TARGET_NAME zero_copy_data_transfer)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
+set(SIMULATOR_TARGET ${TARGET_NAME}.fpga_sim)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 set(REPORTS_TARGET ${TARGET_NAME}_report)
 
@@ -36,6 +37,8 @@ endif()
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
 set(EMULATOR_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fsycl -fintelfpga -Wall -DFPGA_EMULATOR ${DEVICE_FLAG}")
 set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga")
+set(SIMULATOR_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fsycl -fintelfpga -Xssimulation -Wall -DFPGA_SIMULATOR ${DEVICE_FLAG}")
+set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga -Xssimulation -Xshyper-optimized-handshaking=off -Xstarget=${FPGA_DEVICE} ${DEVICE_FLAG} ${USER_SIMULATOR_FLAGS}")
 set(HARDWARE_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fsycl -fintelfpga -Wall ${DEVICE_FLAG}")
 set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xshyper-optimized-handshaking=off -Xstarget=${FPGA_DEVICE} ${DEVICE_FLAG} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
@@ -53,6 +56,20 @@ target_include_directories(${EMULATOR_TARGET} PRIVATE ../../../../include)
 set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
 set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
 add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
+
+###############################################################################
+### FPGA Simulator
+###############################################################################
+# To compile in a single command:
+#    icpx -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR zero_copy_data_transfer.cpp -o zero_copy_data_transfer.fpga_emu
+# CMake executes:
+#    [compile] icpx -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o zero_copy_data_transfer.cpp.o -c zero_copy_data_transfer.cpp
+#    [link]    icpx -fsycl -fintelfpga -Xssimulation zero_copy_data_transfer.cpp.o -o zero_copy_data_transfer.fpga_emu
+add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
+target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 
 ###############################################################################
 ### Generate Report

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
@@ -27,6 +27,9 @@ int main(int argc, char* argv[]) {
 #if defined(FPGA_EMULATOR)
   size_t size = 10000;
   size_t iterations = 1;
+#elif FPGA_SIMULATOR
+  size_t size = 700;
+  size_t iterations = 1;
 #else
   size_t size = 100000000;
   size_t iterations = 5;
@@ -47,6 +50,8 @@ int main(int argc, char* argv[]) {
     // device selector
 #if defined(FPGA_EMULATOR)
     ext::intel::fpga_emulator_selector selector;
+#elif FPGA_SIMULATOR
+    ext::intel::fpga_simulator_selector selector;
 #else
     ext::intel::fpga_selector selector;
 #endif
@@ -134,9 +139,11 @@ int main(int argc, char* argv[]) {
       }
     }
 
-    // The FPGA emulator does not accurately represent the hardware performance
-    // so we don't print performance results when running with the emulator
-#ifndef FPGA_EMULATOR
+    // The FPGA emulator or simulator do not accurately represent the hardware performance
+    // so we don't print performance results when running with the emulator or simulator
+#ifdef FPGA_EMULATOR
+#elif FPGA_SIMULATOR
+#else
     // Compute the average latency across all iterations.
     // We use the first iteration as a 'warmup' for the FPGA,
     // so we ignore its results.


### PR DESCRIPTION
# Existing Sample Changes
## Description

Add support for the FPGA simulator to run the code samples for zero_copy_data_transfer.
Uses ext::intel::fpga_simulator_selector class to choose the simulator.
Reduced data sizes to ensure reasonable execution times, as simulator is 1000-10000x slower than hardware

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used